### PR TITLE
Add sed for "IP Addresses" to generate_cert_from_csr()

### DIFF
--- a/f5acmehandler.sh
+++ b/f5acmehandler.sh
@@ -176,7 +176,7 @@ generate_cert_from_csr() {
    process_errors "DEBUG (handler function: generate_cert_from_csr)\n   DOMAIN=${DOMAIN}\n   COMMAND=${COMMAND}\n"
 
    ## Fetch existing subject-alternative-name (SAN) values from the certificate
-   certsan=$(tmsh list sys crypto cert ${DOMAIN} | grep subject-alternative-name | awk '{$1=$1}1' | sed 's/subject-alternative-name //')
+   certsan=$(tmsh list sys crypto cert ${DOMAIN} | grep subject-alternative-name | awk '{$1=$1}1' | sed 's/subject-alternative-name//' | sed 's/IP Address:/IP:/')
    ## If certsan is empty, assign the domain/CN value
    if [ -z "$certsan" ]
    then


### PR DESCRIPTION
Using F5 BIG-IP 17.0.1 it seems to give an error, while trying to generate CSR from existing private key, when the certificate contains IP Addresses in SAN. So added sed to change `IP Address:` to `IP:`, so it can create the CSR using `tmsh list sys crypto cert` without creating an error.

Also made a change to the `subject-alternative-name`, as there is no trailing space from what I can see.

```
# tmsh list sys crypto cert test-cert.example.com | grep subject-alternative-name | awk '{$1=$1}1' | sed 's/subject-alternative-name //' | sed 's/IP Address:/IP:/'
subject-alternative-name

# tmsh list sys crypto cert test-cert.example.com | grep subject-alternative-name | awk '{$1=$1}1' | sed 's/subject-alternative-name//' | sed 's/IP Address:/IP:/'

```