### PR TITLE
Support wildcard certificates with domain aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project defines a set of utility functions for the [Dehydrated](https://git
 * Simple installation, configuration, and scheduling
 * Supports renewal with existing private keys to enable certificate automation in HSM/FIPS environments
 * Supports per-domain configurations, and multiple ACME providers
+* Supports wildcard certificate creation and renewal
 * Supports OCSP and periodic revocation testing
 * Supports External Account Binding (EAB)
 * Supports SAN certificate renewal
@@ -47,6 +48,7 @@ Installation to the BIG-IP is simple. The only constraint is that the certificat
     www.foo.com := --ca https://acme-v02.api.letsencrypt.org/directory
     www.bar.com := --ca https://acme.zerossl.com/v2/DV90 --config /shared/acme/config_www_example_com
     www.baz.com := --ca https://acme.locallab.com:9000/directory -a rsa
+    *.baz.com   := --ca https://acme.locallab.com:9000/directory --alias star_baz_com
     ```
 
 * ${\normalsize{\textbf{\color{red}Step\ 3}}}$ (Client Configuration): Adjust the client configuration ```config``` file in the /shared/acme folder as needed for your environment. In most cases you will only need a single client config file, but this utility allows for per-domain client configurations. For example, you can define separate config files when EAB is needed for some provider(s), but not others. In an HA environment, the utility ensures these config files are available to the peer. See the **ACME Client Configuration Options** section below for additional details.
@@ -90,6 +92,7 @@ Global configuration options are specified in the ```dg_acme_config``` data grou
 |-------------------|---------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
 | --ca              | Defines the ACME provider URL                                                                                             | --ca https://acme-v02.api.letsencrypt.org/directory (Let's Encrypt)<br /> --ca https://acme-staging-v02.api.letsencrypt.org/directory (LE Staging)<br /> --ca https://acme.zerossl.com/v2/DV90 (ZeroSSL)<br /> --ca https://api.buypass.com/acme/directory (Buypass)<br /> --ca https://api.test4.buypass.no/acme/directory (Buypass Test)<br /> | $${\normalsize{\textbf{\color{red}Yes}}}$$  |
 | --config          | Defines an alternate config file (default: /shared/acme/config)                                                           | --config /shared/acme/config_www_foo_com                                                                                                                                                                                                                                                                                                         | $${\normalsize{\textbf{\color{black}No}}}$$ |
+| --alias           | Specify an alias to be used to reference the certificate intead of a doamin name.  Used to support wildcard certificate management.                                                           | --alias star_example_com 
 | -a                | Overrides the required leaf certificate algorithm specified in the config file. (default: rsa)                            | -a rsa<br /> -a prime256v1<br /> -a secp384r1<br />                                                                                                                                                                                                                                                                                              | $${\normalsize{\textbf{\color{black}No}}}$$ |
 | -d                | Includes additional DNS subject-alternative-name (SAN) values in the certificate. This option can be used multiple times. | -d foo.example.com -d bar.example.com                                                                                                                                                                                                                                                                                                            | $${\normalsize{\textbf{\color{black}No}}}$$ |   
 
@@ -102,11 +105,13 @@ www.foo.com := --ca https://acme-v02.api.letsencrypt.org/directory
 www.bar.com := --ca https://acme.zerossl.com/v2/DV90 --config /shared/acme/config_www_example_com
 www.baz.com := --ca https://acme.locallab.com:9000/directory -a rsa
 www.baz.com := --ca https://acme.locallab.com:9000/directory -a rsa -d foo.baz.com -d bar.baz.com
+*.baz.com   := --ca https://acme.locallab.com:9000/directory --alias star_baz_com
 ```
 
 ***Note the following:***
 * *In using the -d option to include additional SAN values, ACME providers will typically also require validation of these hostnames as well. Ensure that DNS for each of these also resolve to an IP address on the BIG-IP that can answer the ACME challenge.*
 * *The -d option only applies to new certificates. Once a certificate has been created, the ACME renewal will retain the SAN values in the existing certificate.*
+* *The --alias option abstracts the domain name into an alias used internally on the BIG-IP.  The alias is used instead of a domain name within SSL profiles. The alias prevents shell globbing collisions within the BIG-IP for wildcard certificates.  Do not use an asterisk in the alias.*
 <br />
 </details>
 


### PR DESCRIPTION
Wildcard certificates that begin with an asterisk cannot be processed by the f5acmehandler.sh wrapper script due to file globbing issues with the shell.  Using an alias instead (i.e. star_example_com for *.example.com) fixes the issue.

Also update the README.md to include documentation on how to use the alias feature with a wildcard certificate.